### PR TITLE
unchecked slot0 interface

### DIFF
--- a/contracts/interfaces/IUniswapV3PoolSlot0Unchecked.sol
+++ b/contracts/interfaces/IUniswapV3PoolSlot0Unchecked.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 interface IUniswapV3PoolSlot0Unchecked {
+    /// Identical to IUniswapV3PoolState.slot0, but with `uint256` values for
+    /// all the return values that the quoter doesn't need to decode. This
+    /// prevents Solidity from doing overflow checks that can revert otherwise
+    /// compliant pools, if they return values that are too large for the
+    /// canonical slot0 function.
     function slot0()
         external
         view

--- a/contracts/interfaces/IUniswapV3PoolSlot0Unchecked.sol
+++ b/contracts/interfaces/IUniswapV3PoolSlot0Unchecked.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+interface IUniswapV3PoolSlot0Unchecked {
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint256 observationIndex,
+            uint256 observationCardinality,
+            uint256 observationCardinalityNext,
+            uint256 feeProtocol,
+            bool unlocked
+        );
+}

--- a/contracts/libraries/QuoterMath.sol
+++ b/contracts/libraries/QuoterMath.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import {IUniswapV3Pool} from "v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {IUniswapV3PoolSlot0Unchecked} from "../interfaces/IUniswapV3PoolSlot0Unchecked.sol";
 import {IQuoter} from "../interfaces/IQuoter.sol";
 import {SwapMath} from "v3-core/contracts/libraries/SwapMath.sol";
 import {FullMath} from "v3-core/contracts/libraries/FullMath.sol";
@@ -39,25 +40,10 @@ library QuoterMath {
     }
 
     function fillSlot0(IUniswapV3Pool pool) private view returns (Slot0 memory slot0) {
-        (slot0.sqrtPriceX96, slot0.tick,,,,,) = pool.slot0();
+        (slot0.sqrtPriceX96, slot0.tick,,,,,) = IUniswapV3PoolSlot0Unchecked(address(pool)).slot0();
         slot0.tickSpacing = pool.tickSpacing();
 
         return slot0;
-    }
-
-    struct SwapCache {
-        // the protocol fee for the input token
-        uint8 feeProtocol;
-        // liquidity at the beginning of the swap
-        uint128 liquidityStart;
-        // the timestamp of the current block
-        uint32 blockTimestamp;
-        // the current value of the tick accumulator, computed only if we cross an initialized tick
-        int56 tickCumulative;
-        // the current value of seconds per liquidity accumulator, computed only if we cross an initialized tick
-        uint160 secondsPerLiquidityCumulativeX128;
-        // whether we've computed and cached the above two accumulators
-        bool computedLatestObservation;
     }
 
     // the top level state of the swap, the results of which are recorded in storage at the end

--- a/script/Quoter.s.sol
+++ b/script/Quoter.s.sol
@@ -24,34 +24,34 @@ contract MyScript is Script {
         // base chain
         if (chainId == uint256(8453)) {
             return 0x33128a8fC17869897dcE68Ed026d694621f6FDfD;
-        // celo chain
+            // celo chain
         } else if (chainId == uint256(42220)) {
             return 0xAfE208a311B21f13EF87E33A90049fC17A7acDEc;
-        // bsc chain
+            // bsc chain
         } else if (chainId == uint256(56)) {
             return 0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7;
-        // optimism sepolia chain
+            // optimism sepolia chain
         } else if (chainId == uint256(11155420)) {
             return 0x8CE191193D15ea94e11d327b4c7ad8bbE520f6aF;
-        // arbitrum sepolia chain
+            // arbitrum sepolia chain
         } else if (chainId == uint256(421614)) {
             return 0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e;
-        // sepolia chain
+            // sepolia chain
         } else if (chainId == uint256(11155111)) {
             return 0x0227628f3F023bb0B980b67D528571c95c6DaC1c;
-        // avalanche chain
+            // avalanche chain
         } else if (chainId == uint256(43114)) {
             return 0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD;
-        // zora chain
+            // zora chain
         } else if (chainId == uint256(7777777)) {
             return 0x7145F8aeef1f6510E92164038E1B6F8cB2c42Cbb;
-        // zora sepolia chain
+            // zora sepolia chain
         } else if (chainId == uint256(999999999)) {
             return 0x4324A677D74764f46f33ED447964252441aA8Db6;
-        // rookstock chain
+            // rookstock chain
         } else if (chainId == uint256(30)) {
             return 0xaF37EC98A00FD63689CF3060BF3B6784E00caD82;
-        // blast chain
+            // blast chain
         } else if (chainId == uint256(81457)) {
             return 0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd;
         } else {


### PR DESCRIPTION
When I pointed the quoter at non canonical AMMs that implement uniswap v2/v3 broadly, I found an instance of minor non-compliance that makes it impossible to get a quote.

Specifically I found that pancake swap returns protocol fees as `uint32` rather than `uint8` in `slot0`.

The quoter doesn't actually use any of the non-compliant data, and as calldata abi encodes all primitives as 32 byte values regardless of the `uint` bit size, there should be no danger in accepting `uint256` values for anything that is discarded by the quoter anyway.

The issue is that even if the quoter never uses the data, it is decoded and checked for overflows by Solidity according to the interface anyway.

Perhaps this could be considered a bug in Solidity, that ignored data is a revert condition, or perhaps this is desired behaviour upstream as it implies the interfaces differ (which they do in this case, but in a harmless way I believe).

This PR implements a loose version of the `slot0` call that accepts `uint256` for all values that the quoter ignores anyway.

This is a much bigger change than the minimum required to support pancake swap, which would just be a move from `uint8` to `uint32` on the protocol fee. The reason I set all these to `uint256` is that I didn't want to overfit for pancake swap specifically. In the scheme of things I don't really care about pancake swap, I'm more interested in being able to use the quoter in as many situations as possible.